### PR TITLE
Allow source_directory to be a pathlib.Path

### DIFF
--- a/changelogs/fragments/6-collection-copier-strpath.yml
+++ b/changelogs/fragments/6-collection-copier-strpath.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "``CollectionCopier``'s ``source_directory`` argument did not accept ``pathlib.Path`` (https://github.com/ansible-community/antsibull-fileutils/pull/6)."

--- a/changelogs/fragments/6-collection-copier-strpath.yml
+++ b/changelogs/fragments/6-collection-copier-strpath.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "``CollectionCopier``'s ``source_directory`` argument did not accept ``pathlib.Path`` (https://github.com/ansible-community/antsibull-fileutils/pull/6)."
+  - "``CollectionCopier``'s ``source_directory`` argument now accepts ``pathlib.Path`` objects in addition to ``str``s (https://github.com/ansible-community/antsibull-fileutils/pull/6)."

--- a/changelogs/fragments/6-collection-copier-strpath.yml
+++ b/changelogs/fragments/6-collection-copier-strpath.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "``CollectionCopier``'s ``source_directory`` argument now accepts ``pathlib.Path`` objects in addition to ``str``s (https://github.com/ansible-community/antsibull-fileutils/pull/6)."
+  - "``CollectionCopier``'s ``source_directory`` argument now accepts ``pathlib.Path`` objects in addition to ``str``\ s (https://github.com/ansible-community/antsibull-fileutils/pull/6)."

--- a/src/antsibull_fileutils/copier.py
+++ b/src/antsibull_fileutils/copier.py
@@ -107,7 +107,7 @@ class CollectionCopier:
     def __init__(
         self,
         *,
-        source_directory: str,
+        source_directory: StrPath,
         namespace: str,
         name: str,
         copier: Copier,


### PR DESCRIPTION
While this can be seen as a feature, I think it's more a bugfix.