### PR TITLE
GitCopier: handle symlinks correctly

### DIFF
--- a/changelogs/fragments/7-symlink.yml
+++ b/changelogs/fragments/7-symlink.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Make ``GitCopier`` handle symlinks correctly (https://github.com/ansible-community/antsibull-fileutils/pull/7)."

--- a/src/antsibull_fileutils/copier.py
+++ b/src/antsibull_fileutils/copier.py
@@ -95,7 +95,7 @@ class GitCopier(Copier):
 
             # Copy the file
             dst_path = os.path.join(to_path, file_decoded)
-            shutil.copyfile(src_path, dst_path)
+            shutil.copyfile(src_path, dst_path, follow_symlinks=False)
 
 
 class CollectionCopier:

--- a/tests/units/test_copier.py
+++ b/tests/units/test_copier.py
@@ -22,16 +22,16 @@ from .utils import collect_log
 
 
 def assert_same(a: pathlib.Path, b: pathlib.Path) -> None:
+    if a.is_symlink():
+        assert b.is_symlink()
+        assert a.readlink() == b.readlink()
+        return
     if a.is_file():
         assert b.is_file()
         assert a.read_bytes() == b.read_bytes()
         return
     if a.is_dir():
         assert b.is_dir()
-        return
-    if a.is_symlink():
-        assert b.is_symlink()
-        assert a.readlink() == b.readlink()
         return
 
 


### PR DESCRIPTION
Right now it copies the symlink's contents, which is usually not a good idea, and leads to exceptions if the symlink points to a directory or the destination does not exist.