### PR TITLE
Add Python 3.13 to CI and supported Python versions

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -33,12 +33,12 @@ jobs:
       matrix:
         include:
           - session: test
-            python-versions: "3.9, 3.10, 3.11, 3.12"
+            python-versions: "3.9, 3.10, 3.11, 3.12, 3.13"
             codecov: true
             packages: ""
 
           - session: lint
-            python-versions: "3.12"
+            python-versions: "3.13"
             codecov: false
             packages: ""
     name: "Run nox ${{ matrix.session }} session"

--- a/changelogs/fragments/python-3.13.yml
+++ b/changelogs/fragments/python-3.13.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Declare support for Python 3.13 (https://github.com/ansible-community/antsibull-fileutils/pull/10).

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,7 @@ def install(session: nox.Session, *args, editable=False, **kwargs):
     session.install(*args, "-U", **kwargs)
 
 
-@nox.session(python=["3.9", "3.10", "3.11", "3.12"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def test(session: nox.Session):
     install(
         session,
@@ -42,7 +42,7 @@ def test(session: nox.Session):
     )
     covfile = Path(session.create_tmp(), ".coverage")
     more_args = []
-    if session.python == "3.12":
+    if session.python in {"3.12", "3.13"}:
         more_args.append("--error-for-skips")
     session.run(
         "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
Since Python 3.13.0 has been released, let's use it in CI and officially support it.