### PR TITLE
Allow to exclude top-level files and dirs when copying trees

### DIFF
--- a/changelogs/fragments/14-exclude-root.yml
+++ b/changelogs/fragments/14-exclude-root.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Allow to exclude top-level files and directories when copying trees (https://github.com/ansible-community/antsibull-fileutils/pull/14)."


### PR DESCRIPTION
Needed for https://github.com/ansible-community/antsibull-nox/pull/1 so we don't copy `.nox` (if its not part of `.gitignore`, or there's no Git repo).