### PR TITLE
GitCopier: handle untracked dirs correctly

### DIFF
--- a/changelogs/fragments/30-git-directories.yml
+++ b/changelogs/fragments/30-git-directories.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Fix ``GitCopier`` to correctly copy untracked directories. Right now it wrongly assumes everything untracked is a file
+     and tries to copy it as a file, which fails for directories (https://github.com/ansible-community/antsibull-fileutils/pull/30)."

--- a/src/antsibull_fileutils/copier.py
+++ b/src/antsibull_fileutils/copier.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import stat
 import typing as t
 
 from antsibull_fileutils.tempfile import ansible_mkdtemp
@@ -201,6 +202,20 @@ class GitCopier(Copier):
         self.git_bin_path = git_bin_path
         self.copy_repo_structure = copy_repo_structure
 
+    def _copy_directory(
+        self,
+        *,
+        from_path: StrPath,
+        to_path: StrPath,
+        path: str,
+    ) -> None:
+        _TreeCopier(
+            os.path.join(from_path, path),
+            os.path.join(to_path, path),
+            normalize_links=self.normalize_links,
+            log_debug=self._log_debug,
+        ).walk()
+
     def copy(
         self,
         from_path: StrPath,
@@ -237,15 +252,21 @@ class GitCopier(Copier):
                 continue
             if any(file_decoded.startswith(prefix) for prefix in exclude_root_prefixes):
                 continue
-            tc.copy_file(file_decoded, ignore_non_existing=True)
+            try:
+                st = os.lstat(os.path.join(from_path, file_decoded))
+                is_dir = stat.S_ISDIR(st.st_mode)
+            except FileNotFoundError:
+                # This shouldn't really happen, except in tests...
+                is_dir = False
+            if is_dir:
+                self._copy_directory(
+                    from_path=from_path, to_path=to_path, path=file_decoded
+                )
+            else:
+                tc.copy_file(file_decoded, ignore_non_existing=True)
         # Copy .git directory as well if requested
         if self.copy_repo_structure and os.path.isdir(os.path.join(from_path, ".git")):
-            _TreeCopier(
-                os.path.join(from_path, ".git"),
-                os.path.join(to_path, ".git"),
-                normalize_links=self.normalize_links,
-                log_debug=self._log_debug,
-            ).walk()
+            self._copy_directory(from_path=from_path, to_path=to_path, path=".git")
 
 
 class CollectionCopier:

--- a/tests/units/test_copier.py
+++ b/tests/units/test_copier.py
@@ -212,6 +212,9 @@ def test_git_copier(tmp_path_factory):
     (src_dir / "file").write_text("content", encoding="utf-8")
     (src_dir / "dir" / "binary_file").write_bytes(b"\x00\x01\x02")
     (src_dir / "dir" / "another_file").write_text("more", encoding="utf-8")
+    (src_dir / ".git").mkdir()
+    (src_dir / ".git" / "foo").write_text("some git file", encoding="utf-8")
+    (src_dir / ".git" / "bar").write_text("another git file", encoding="utf-8")
 
     dest_dir = directory / "dest1"
     with mock.patch(
@@ -392,7 +395,9 @@ def test_git_copier(tmp_path_factory):
         return_value=[b"dir/"],
     ) as m:
         kwargs, debug, info = collect_log(with_info=False)
-        copier = GitCopier(git_bin_path="/path/to/git", **kwargs)
+        copier = GitCopier(
+            git_bin_path="/path/to/git", copy_repo_structure=True, **kwargs
+        )
         copier.copy(src_dir, dest_dir)
         m.assert_called_with(src_dir, git_bin_path="/path/to/git", **kwargs)
 
@@ -413,13 +418,32 @@ def test_git_copier(tmp_path_factory):
                     os.path.join(dest_dir, "dir", "binary_file"),
                 ),
             ),
+            (
+                "Copying file {!r} to {!r}",
+                (
+                    os.path.join(src_dir, ".git", "bar"),
+                    os.path.join(dest_dir, ".git", "bar"),
+                ),
+            ),
+            (
+                "Copying file {!r} to {!r}",
+                (
+                    os.path.join(src_dir, ".git", "foo"),
+                    os.path.join(dest_dir, ".git", "foo"),
+                ),
+            ),
         ]
         assert dest_dir.is_dir()
-        assert {p.name for p in dest_dir.iterdir()} == {"dir"}
+        assert {p.name for p in dest_dir.iterdir()} == {"dir", ".git"}
         assert (dest_dir / "dir").is_dir()
         assert {p.name for p in (dest_dir / "dir").iterdir()} == {
             "another_file",
             "binary_file",
+        }
+        assert (dest_dir / ".git").is_dir()
+        assert {p.name for p in (dest_dir / ".git").iterdir()} == {
+            "foo",
+            "bar",
         }
 
 

--- a/tests/units/test_copier.py
+++ b/tests/units/test_copier.py
@@ -386,6 +386,42 @@ def test_git_copier(tmp_path_factory):
         assert dest_dir.is_dir()
         assert {p.name for p in dest_dir.iterdir()} == set()
 
+    dest_dir = directory / "dest8"
+    with mock.patch(
+        "antsibull_fileutils.copier.list_git_files",
+        return_value=[b"dir/"],
+    ) as m:
+        kwargs, debug, info = collect_log(with_info=False)
+        copier = GitCopier(git_bin_path="/path/to/git", **kwargs)
+        copier.copy(src_dir, dest_dir)
+        m.assert_called_with(src_dir, git_bin_path="/path/to/git", **kwargs)
+
+        assert debug == [
+            ("Identifying files not ignored by Git in {!r}", (src_dir,)),
+            ("Copying {} file(s) from {!r} to {!r}", (1, src_dir, dest_dir)),
+            (
+                "Copying file {!r} to {!r}",
+                (
+                    os.path.join(src_dir, "dir", "another_file"),
+                    os.path.join(dest_dir, "dir", "another_file"),
+                ),
+            ),
+            (
+                "Copying file {!r} to {!r}",
+                (
+                    os.path.join(src_dir, "dir", "binary_file"),
+                    os.path.join(dest_dir, "dir", "binary_file"),
+                ),
+            ),
+        ]
+        assert dest_dir.is_dir()
+        assert {p.name for p in dest_dir.iterdir()} == {"dir"}
+        assert (dest_dir / "dir").is_dir()
+        assert {p.name for p in (dest_dir / "dir").iterdir()} == {
+            "another_file",
+            "binary_file",
+        }
+
 
 def test_collection_copier(tmp_path_factory):
     src_dir: pathlib.Path = tmp_path_factory.mktemp("collection-copier")

--- a/tests/units/test_copier.py
+++ b/tests/units/test_copier.py
@@ -214,7 +214,6 @@ def test_git_copier(tmp_path_factory):
     (src_dir / "dir" / "another_file").write_text("more", encoding="utf-8")
     (src_dir / ".git").mkdir()
     (src_dir / ".git" / "foo").write_text("some git file", encoding="utf-8")
-    (src_dir / ".git" / "bar").write_text("another git file", encoding="utf-8")
 
     dest_dir = directory / "dest1"
     with mock.patch(
@@ -401,38 +400,59 @@ def test_git_copier(tmp_path_factory):
         copier.copy(src_dir, dest_dir)
         m.assert_called_with(src_dir, git_bin_path="/path/to/git", **kwargs)
 
-        assert debug == [
-            ("Identifying files not ignored by Git in {!r}", (src_dir,)),
-            ("Copying {} file(s) from {!r} to {!r}", (1, src_dir, dest_dir)),
-            (
-                "Copying file {!r} to {!r}",
+        assert debug in (
+            # There are two possible orders of another_file and binary_file in dir/:
+            [
+                ("Identifying files not ignored by Git in {!r}", (src_dir,)),
+                ("Copying {} file(s) from {!r} to {!r}", (1, src_dir, dest_dir)),
                 (
-                    os.path.join(src_dir, "dir", "another_file"),
-                    os.path.join(dest_dir, "dir", "another_file"),
+                    "Copying file {!r} to {!r}",
+                    (
+                        os.path.join(src_dir, "dir", "another_file"),
+                        os.path.join(dest_dir, "dir", "another_file"),
+                    ),
                 ),
-            ),
-            (
-                "Copying file {!r} to {!r}",
                 (
-                    os.path.join(src_dir, "dir", "binary_file"),
-                    os.path.join(dest_dir, "dir", "binary_file"),
+                    "Copying file {!r} to {!r}",
+                    (
+                        os.path.join(src_dir, "dir", "binary_file"),
+                        os.path.join(dest_dir, "dir", "binary_file"),
+                    ),
                 ),
-            ),
-            (
-                "Copying file {!r} to {!r}",
                 (
-                    os.path.join(src_dir, ".git", "bar"),
-                    os.path.join(dest_dir, ".git", "bar"),
+                    "Copying file {!r} to {!r}",
+                    (
+                        os.path.join(src_dir, ".git", "foo"),
+                        os.path.join(dest_dir, ".git", "foo"),
+                    ),
                 ),
-            ),
-            (
-                "Copying file {!r} to {!r}",
+            ],
+            [
+                ("Identifying files not ignored by Git in {!r}", (src_dir,)),
+                ("Copying {} file(s) from {!r} to {!r}", (1, src_dir, dest_dir)),
                 (
-                    os.path.join(src_dir, ".git", "foo"),
-                    os.path.join(dest_dir, ".git", "foo"),
+                    "Copying file {!r} to {!r}",
+                    (
+                        os.path.join(src_dir, "dir", "binary_file"),
+                        os.path.join(dest_dir, "dir", "binary_file"),
+                    ),
                 ),
-            ),
-        ]
+                (
+                    "Copying file {!r} to {!r}",
+                    (
+                        os.path.join(src_dir, "dir", "another_file"),
+                        os.path.join(dest_dir, "dir", "another_file"),
+                    ),
+                ),
+                (
+                    "Copying file {!r} to {!r}",
+                    (
+                        os.path.join(src_dir, ".git", "foo"),
+                        os.path.join(dest_dir, ".git", "foo"),
+                    ),
+                ),
+            ],
+        )
         assert dest_dir.is_dir()
         assert {p.name for p in dest_dir.iterdir()} == {"dir", ".git"}
         assert (dest_dir / "dir").is_dir()
@@ -443,7 +463,6 @@ def test_git_copier(tmp_path_factory):
         assert (dest_dir / ".git").is_dir()
         assert {p.name for p in (dest_dir / ".git").iterdir()} == {
             "foo",
-            "bar",
         }
 
 


### PR DESCRIPTION
Right now, it assumes every untracked item is a file (or link). An untracked directory causes a crash.